### PR TITLE
Add Mqtt support and clean up

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,7 +24,7 @@ jobs:
 #    - name: Test
 #      run: dotnet test --no-restore --verbosity normal
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
       with:
         fetch-depth: '0'
     - name: Bump version and push tag

--- a/DetectiCam.Core/DetectiCam.Core.csproj
+++ b/DetectiCam.Core/DetectiCam.Core.csproj
@@ -10,15 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="M2Mqtt" Version="4.3.0" />
+    <PackageReference Include="M2MqttDotnetCore" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
     <PackageReference Include="OpenCvSharp4" Version="4.3.0.20200701" />
     <PackageReference Include="OpenCvSharp4.runtime.ubuntu.18.04-x64" Version="4.3.0.20200701" />
     <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.3.0.20200701" />

--- a/DetectiCam.Core/DetectiCam.Core.csproj
+++ b/DetectiCam.Core/DetectiCam.Core.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="M2Mqtt" Version="4.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DetectiCam.Core/Detection/Yolo3BatchedDnnDetector.cs
+++ b/DetectiCam.Core/Detection/Yolo3BatchedDnnDetector.cs
@@ -74,11 +74,13 @@ namespace DetectiCam.Core.Detection
         {
             _logger.LogInformation("Start Detector initalize");
             using Mat dummy1 = new Mat(320, 320, MatType.CV_8UC3, new Scalar(0,0,255));
-            //using Mat dummy2 = new Mat(320, 320, MatType.CV_8UC3, new Scalar(0, 0, 255));
+            using Mat dummy2 = new Mat(320, 320, MatType.CV_8UC3, new Scalar(0, 0, 255));
 
-            var images = new List<Mat>();
-            images.Add(dummy1);
-            //images.Add(dummy2);
+            var images = new List<Mat>
+            {
+                dummy1,
+                dummy2
+            };
             var res = ClassifyObjects(images);
             _logger.LogInformation("Detector initalized");
         }

--- a/DetectiCam.Core/Pipeline/AnalysisResultsChannelConsumer.cs
+++ b/DetectiCam.Core/Pipeline/AnalysisResultsChannelConsumer.cs
@@ -63,5 +63,10 @@ namespace DetectiCam.Core.VideoCapturing
             }
         }
 
+        public override Task StopProcessingAsync(CancellationToken cancellationToken)
+        {
+            _resultProcessors.ForEach(async p => await p.StopProcessingAsync(cancellationToken).ConfigureAwait(false));
+            return base.StopProcessingAsync(cancellationToken);
+        }
     }
 }

--- a/DetectiCam.Core/Pipeline/ChannelConsumer.cs
+++ b/DetectiCam.Core/Pipeline/ChannelConsumer.cs
@@ -66,12 +66,12 @@ namespace DetectiCam.Core.VideoCapturing
             return _processorTask;
         }
 
-        public async Task StopProcessingAsync(CancellationToken cancellationToken)
+        public virtual async Task StopProcessingAsync(CancellationToken cancellationToken)
         {
             _internalCts.Cancel();
             if (_processorTask != null)
             {
-                await _processorTask;
+                await _processorTask.ConfigureAwait(false);
                 _processorTask = null;
             }
         }

--- a/DetectiCam.Core/Pipeline/ChannelConsumer.cs
+++ b/DetectiCam.Core/Pipeline/ChannelConsumer.cs
@@ -52,7 +52,7 @@ namespace DetectiCam.Core.VideoCapturing
                         await _processor(inputValue, linkedToken).ConfigureAwait(false);
                     }
                 }
-                catch (OperationCanceledException oc)
+                catch (OperationCanceledException)
                 {
                     _logger.LogWarning("Consume operation cancelled");
                     throw;

--- a/DetectiCam.Core/Pipeline/ChannelTransformer.cs
+++ b/DetectiCam.Core/Pipeline/ChannelTransformer.cs
@@ -59,7 +59,7 @@ namespace DetectiCam.Core.VideoCapturing
                         }
                     }
                 }
-                catch (OperationCanceledException oc)
+                catch (OperationCanceledException)
                 {
                     _logger.LogWarning("Transform operation cancelled");
                     throw;
@@ -75,7 +75,7 @@ namespace DetectiCam.Core.VideoCapturing
             return _processorTask;
         }
 
-        public async Task StopProcessingAsync(CancellationToken cancellationToken)
+        public async Task StopProcessingAsync()
         {
             _internalCts.Cancel();
             if (_processorTask != null)

--- a/DetectiCam.Core/Pipeline/ChannelTransformer.cs
+++ b/DetectiCam.Core/Pipeline/ChannelTransformer.cs
@@ -80,7 +80,7 @@ namespace DetectiCam.Core.VideoCapturing
             _internalCts.Cancel();
             if (_processorTask != null)
             {
-                await _processorTask;
+                await _processorTask.ConfigureAwait(false);
                 _processorTask = null;
             }
         }

--- a/DetectiCam.Core/Pipeline/DnnDetectorChannelTransformer.cs
+++ b/DetectiCam.Core/Pipeline/DnnDetectorChannelTransformer.cs
@@ -16,7 +16,6 @@ namespace DetectiCam.Core.Pipeline
     public class DnnDetectorChannelTransformer : ChannelTransformer<IList<VideoFrame>, AnalysisResult>
     {
         private readonly IBatchedDnnDetector _detector;
-        private readonly TimeSpan _analysisTimeout = TimeSpan.FromSeconds(3);
 
         public DnnDetectorChannelTransformer(IBatchedDnnDetector detector,
             ChannelReader<IList<VideoFrame>> inputReader, ChannelWriter<AnalysisResult> outputWriter,

--- a/DetectiCam.Core/Pipeline/MultiChannelMerger.cs
+++ b/DetectiCam.Core/Pipeline/MultiChannelMerger.cs
@@ -14,7 +14,7 @@ namespace DetectiCam.Core.VideoCapturing
         private readonly ChannelWriter<IList<T>> _outputWriter;
         private readonly ILogger _logger;
         private Task? _mergeTask = null;
-        private CancellationTokenSource _internalCts;
+        private readonly CancellationTokenSource _internalCts;
         private bool disposedValue;
 
         public MultiChannelMerger(IEnumerable<ChannelReader<T>> inputReaders, ChannelWriter<IList<T>> outputWriter,
@@ -87,7 +87,7 @@ namespace DetectiCam.Core.VideoCapturing
             _internalCts.Cancel();
             if (_mergeTask != null)
             {
-                await _mergeTask;
+                await _mergeTask.ConfigureAwait(false);
                 _mergeTask = null;
             }
         }

--- a/DetectiCam.Core/Pipeline/MultiChannelMerger.cs
+++ b/DetectiCam.Core/Pipeline/MultiChannelMerger.cs
@@ -82,7 +82,7 @@ namespace DetectiCam.Core.VideoCapturing
             return _mergeTask;
         }
 
-        public async Task StopProcessingAsync(CancellationToken cancellationToken)
+        public async Task StopProcessingAsync()
         {
             _internalCts.Cancel();
             if (_mergeTask != null)

--- a/DetectiCam.Core/Pipeline/MultiStreamBatchedProcessorPipeline.cs
+++ b/DetectiCam.Core/Pipeline/MultiStreamBatchedProcessorPipeline.cs
@@ -175,7 +175,7 @@ namespace DetectiCam.Core.VideoCapturing
             _logger.LogInformation("Stopping merger");
             if (_merger != null)
             {
-                await _merger.StopProcessingAsync(default).ConfigureAwait(false);
+                await _merger.StopProcessingAsync().ConfigureAwait(false);
                 _merger.Dispose();
                 _merger = null;
             }
@@ -183,7 +183,7 @@ namespace DetectiCam.Core.VideoCapturing
             _logger.LogInformation("Stopping analyzer");
             if (_analyzer != null)
             {
-                await _analyzer.StopProcessingAsync(default).ConfigureAwait(false);
+                await _analyzer.StopProcessingAsync().ConfigureAwait(false);
                 _analyzer.Dispose();
                 _analyzer = null;
             }

--- a/DetectiCam.Core/ResultProcessor/AnnotatedImagePublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/AnnotatedImagePublisher.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DetectiCam.Core.ResultProcessor
@@ -70,6 +71,11 @@ namespace DetectiCam.Core.ResultProcessor
             Cv2.ImWrite(filePath, result);
             _logger.LogInformation($"Interesting Detection Saved: {filename}");
 
+            return Task.CompletedTask;
+        }
+
+        public Task StopProcessingAsync(CancellationToken cancellationToken)
+        {
             return Task.CompletedTask;
         }
     }

--- a/DetectiCam.Core/ResultProcessor/IAsyncResultProcessor.cs
+++ b/DetectiCam.Core/ResultProcessor/IAsyncResultProcessor.cs
@@ -4,6 +4,7 @@ using OpenCvSharp;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DetectiCam.Core.ResultProcessor
@@ -11,5 +12,6 @@ namespace DetectiCam.Core.ResultProcessor
     public interface IAsyncSingleResultProcessor
     {
         Task ProcessResultAsync(VideoFrame frame, DnnDetectedObject[] results);
+        Task StopProcessingAsync(CancellationToken cancellationToken);
     }
 }

--- a/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
@@ -1,0 +1,104 @@
+﻿using DetectiCam.Core.Detection;
+using DetectiCam.Core.VideoCapturing;
+using DetectiCam.Core.Visualization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using uPLibrary.Networking.M2Mqtt;
+using uPLibrary.Networking.M2Mqtt.Messages;
+
+namespace DetectiCam.Core.ResultProcessor
+{
+    public class MqttPublisher : IAsyncSingleResultProcessor
+    {
+        private readonly ILogger _logger;
+        private readonly MqttClient? _client;
+        private readonly MqttPublisherOptions? _config;
+        private readonly bool _isEnabled = false;
+        private readonly string? _topicPrefix;
+
+        public MqttPublisher(   IOptions<MqttPublisherOptions> config,
+                                ILogger<MqttPublisher> logger)
+        {
+            if (config is null) throw new ArgumentNullException(nameof(config));
+            if (logger is null) throw new ArgumentNullException(nameof(logger));
+
+            _logger = logger;
+
+            try
+            {
+                _config = config.Value;
+                _isEnabled = _config.Enabled;
+
+                if (_isEnabled)
+                {
+                    if (!String.IsNullOrEmpty(_config.TopicPrefix))
+                    {
+                        _topicPrefix = _config.TopicPrefix;
+                        if (!_config.TopicPrefix.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+                        {
+                            _topicPrefix += "/";
+                        }
+                    }
+                    else
+                    {
+                        _topicPrefix = "";
+                    }
+
+                    // create client instance 
+                    _client = new MqttClient(_config.Server, _config.Port, false,
+                        MqttSslProtocols.None,
+                        null, null);
+
+                    string clientId = String.IsNullOrEmpty(_config.ClientId) ? Guid.NewGuid().ToString() :
+                        _config.ClientId;
+
+                    _client.Connect(clientId, _config.Username, _config.Password);
+                }
+            }
+            catch (OptionsValidationException ex)
+            {
+                foreach (var failure in ex.Failures)
+                {
+                    _logger.LogError(failure);
+                }
+            }
+        }
+
+        public Task ProcessResultAsync(VideoFrame frame, DnnDetectedObject[] results)
+        {
+            if (_isEnabled && _client != null)
+            {
+
+                if (frame is null) throw new ArgumentNullException(nameof(frame));
+                if (results is null) throw new ArgumentNullException(nameof(results));
+
+                string strValue = "{ \"dectection\" : true }";
+                string topic = $"{_topicPrefix}detect-i-cam/{frame.Metadata.Info.Id}/";
+
+                // publish a message on "/home/temperature" topic with QoS 2 
+                _client.Publish(topic,
+                    Encoding.UTF8.GetBytes(strValue),
+                    MqttMsgBase.QOS_LEVEL_AT_LEAST_ONCE, false);
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task StopProcessingAsync(CancellationToken cancellationToken)
+        {
+            _client?.Disconnect();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
@@ -84,8 +84,8 @@ namespace DetectiCam.Core.ResultProcessor
                 if (frame is null) throw new ArgumentNullException(nameof(frame));
                 if (results is null) throw new ArgumentNullException(nameof(results));
 
-                string strValue = "{ \"dectection\" : true }";
-                string topic = $"{_topicPrefix}detect-i-cam/{frame.Metadata.Info.Id}/";
+                string strValue = "{ \"detection\" : true }";
+                string topic = $"{_topicPrefix}detect-i-cam/{frame.Metadata.Info.Id}/state";
 
                 // publish a message on "/home/temperature" topic with QoS 2 
                 _client.Publish(topic,

--- a/DetectiCam.Core/ResultProcessor/MqttPublisherOptions.cs
+++ b/DetectiCam.Core/ResultProcessor/MqttPublisherOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace DetectiCam.Core.Detection
+{
+    public class MqttPublisherOptions
+    {
+        public const string MqttPublisher = "mqtt-publisher";
+
+        public bool Enabled { get; set; } 
+        public string Server { get; set; } = default!;
+        public int Port { get; set; } = 1883;
+        public string? Username { get; set; }
+        public string? Password { get; set; }
+        public string? TopicPrefix { get; set; } 
+        public string? ClientId { get; set; }
+    }
+}

--- a/DetectiCam.Core/ResultProcessor/WebhookPublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/WebhookPublisher.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DetectiCam.Core.ResultProcessor
@@ -34,9 +35,15 @@ namespace DetectiCam.Core.ResultProcessor
             var url = frame.Metadata.Info.CallbackUrl;
             if (url != null)
             {
+                _logger.LogInformation("Webhook notify for {streamId}", frame.Metadata.Info.Id);
                 using var client = _clientFactory.CreateClient();
                 await client.GetAsync(url).ConfigureAwait(false);
             }
+        }
+
+        public Task StopProcessingAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
+++ b/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
@@ -37,11 +37,6 @@ namespace DetectiCam.Core.VideoCapturing
         public VideoStreamInfo Info { get; }
         public Channel<VideoFrame> OutputChannel { get; }
 
-        //public VideoStreamGrabber(ILogger logger, string streamName, string path, double fps = 0, bool isContinuous = true, RotateFlags? rotateFlags = null)
-        //    : this(logger, new VideoStreamInfo() { Id = streamName, Path = path, Fps = fps, IsContinuous = isContinuous, RotateFlags = rotateFlags })
-        //{
-        //}
-
         public VideoStreamGrabber(ILogger logger, VideoStreamInfo streamInfo, Channel<VideoFrame> outputChannel)
         {
             if (logger is null) throw new ArgumentNullException(nameof(logger));

--- a/DetectiCam.Core/VideoCapturing/VideoStreamsConfig.cs
+++ b/DetectiCam.Core/VideoCapturing/VideoStreamsConfig.cs
@@ -6,5 +6,4 @@ namespace DetectiCam.Core.VideoCapturing
     {
         public const string VideoStreamsConfigKey = "video-streams";
     }
-
 }

--- a/DetectiCam.CoreTests/DetectiCam.CoreTests.csproj
+++ b/DetectiCam.CoreTests/DetectiCam.CoreTests.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/DetectiCam.CoreTests/VideoCapturing/MultiChannelMergerTests.cs
+++ b/DetectiCam.CoreTests/VideoCapturing/MultiChannelMergerTests.cs
@@ -106,7 +106,7 @@ namespace DetectiCam.Core.VideoCapturing.Tests
                 _secondInput.Writer.Complete();
             });
 
-            await _sut.StopProcessingAsync(_cts.Token);
+            await _sut.StopProcessingAsync();
 
             if(_output.Reader.TryRead(out var result))
             {

--- a/DetectiCam.CoreTests/VideoCapturing/MultiChannelMergerTests.cs
+++ b/DetectiCam.CoreTests/VideoCapturing/MultiChannelMergerTests.cs
@@ -38,9 +38,11 @@ namespace DetectiCam.Core.VideoCapturing.Tests
             //or use this short equivalent 
             _logger = Mock.Of<ILogger<MultiChannelMerger<int>>>();
 
-            _inputs = new List<ChannelReader<int>>();
-            _inputs.Add(_firstInput.Reader);
-            _inputs.Add(_secondInput.Reader);
+            _inputs = new List<ChannelReader<int>>
+            {
+                _firstInput.Reader,
+                _secondInput.Reader
+            };
 
             _sut = new MultiChannelMerger<int>(_inputs, _output.Writer, _logger);
         }

--- a/DetectiCam.sln
+++ b/DetectiCam.sln
@@ -6,14 +6,13 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{94B75B7B-7D23-4CE7-AD2C-F8D3FF0AB214}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		..\opencv\install-opencv-linux.sh = ..\opencv\install-opencv-linux.sh
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DetectiCam", "DetectiCam\DetectiCam.csproj", "{0E48618E-4A37-4C68-B8A2-4E8B0A9A2116}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DetectiCam.Core", "DetectiCam.Core\DetectiCam.Core.csproj", "{D8587B25-B279-44DD-BBA6-50B3AB51DCD7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DetectiCam.CoreTests", "DetectiCam.CoreTests\DetectiCam.CoreTests.csproj", "{053C8D88-B3DF-41D2-8CE8-3ED030BDC113}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DetectiCam.CoreTests", "DetectiCam.CoreTests\DetectiCam.CoreTests.csproj", "{053C8D88-B3DF-41D2-8CE8-3ED030BDC113}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/DetectiCam/DetectiCam.csproj
+++ b/DetectiCam/DetectiCam.csproj
@@ -16,9 +16,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.6" />
     <PackageReference Include="Microsoft.NetCore.Platforms" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />

--- a/DetectiCam/DetectiCam.csproj
+++ b/DetectiCam/DetectiCam.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.6" />
     <PackageReference Include="Microsoft.NetCore.Platforms" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
     <PackageReference Include="OpenCvSharp4" Version="4.3.0.20200701" />

--- a/DetectiCam/Program.cs
+++ b/DetectiCam/Program.cs
@@ -27,6 +27,10 @@ namespace CameraWatcher
             })
             .ConfigureServices((hostContext, services) =>
             {
+                services.AddOptions<MqttPublisherOptions>()
+                    .Bind(hostContext.Configuration.GetSection(MqttPublisherOptions.MqttPublisher))
+                    .ValidateDataAnnotations();
+
                 var generateConfig = hostContext.Configuration.GetValue<bool>("gen-config");
                 if (generateConfig)
                 {
@@ -40,6 +44,7 @@ namespace CameraWatcher
                     services.AddSingleton<IBatchedDnnDetector, Yolo3BatchedDnnDetector>();
                     services.AddSingleton<IAsyncSingleResultProcessor, AnnotatedImagePublisher>();
                     services.AddSingleton<IAsyncSingleResultProcessor, WebhookPublisher>();
+                    services.AddSingleton<IAsyncSingleResultProcessor, MqttPublisher>();
 
                     services.AddSingleton<MultiStreamBatchedProcessorPipeline,
                         MultiStreamBatchedProcessorPipeline>();

--- a/README.md
+++ b/README.md
@@ -69,9 +69,53 @@ Only the id and path are required. A path can be a videostream file (need to be 
 * *fps*: Optional, only needed if the log shows that the settings cannot be picked up from the stream. If nothing can be found, and not specified, defaults to 30.
 * *callbackUr*l: Optional, webhook to trigger on detection
 
-### Captures or Callback
+## Act on detections
+
+### Capturing Detections to disk
 By default, all captured images containing a "person" are written to the /captures volume, including bounding boxes of all detected objects and their confidence percentage.
-When you want to integrate with other solutions, you can specifiy a callback url. In the example I am using a webhook to trigger recording on my synology NAS.
+If you dont want this, you can make the capturepath empty in the appsettings.json:
+
+```
+"capture-path": null,
+```
+
+### Webhook Notification
+When you want to integrate with other solutions by using a webhook, you can specifiy a callback url. As part of the video-steam config. 
+In the example I am using a webhook to trigger recording on my synology NAS.
+
+### MQTT Publications
+Another option is to use MQTT publication. The following configuration can be used in the appsettings.json:
+```
+"mqtt-publisher": {
+   "enabled": true,
+   "server": "nuc.home",
+   "port": 1883,
+    "username": "myuser",
+    "password": "passwd",
+     "topicPrefix": "home",
+     "clientId": "detecticam"
+ }
+```
+* *enabled*: Mandatory to enable it, by default is set to false.
+* *server*: Mandatory, Mqtt server to use
+* *port*: Optional, default set to 1883.
+* *username*: Optional, default null.
+* *password*: Optional, default null.
+* *topicPrefix*: Optional, default ""
+* *clientId*: Optional, by default a unique id (guid) is generated
+
+Currently only an unsecure connection is supported, so we don't have to configure certificates etc.
+
+A message will be published each time a person is detected.
+The message is published on the topic:
+```
+[<topicPrefix>/]detect-i-cam/<stream-id>/state
+```
+
+The value of the message is currently only:
+```
+{ "detection" : true }
+```
 
 ### Rolling your own network
 


### PR DESCRIPTION
I have created a first version of MQTT support as discussed in #2 .

The following configuration can be used in the appsettings.json:
 ```
"mqtt-publisher": {
    "enabled": true,
    "server": "nuc.home",
    "port": 1883, //optional, default value
     "username": "myuser", //optional
     "password": "passwd", //optional
      "topicPrefix": "home", //optional
      "clientId": "detecticam" //optional, guid by default
  }
```
Now only an unsecure connection is supported, so we don't have to configure certificates etc.

A message will be published each time a person is detected.
The message is published on the topic: 
```
<topicPrefix>/detect-i-cam/<stream-id>
```
The value of the message is currently only:
```
{ "dectection" : true }
```