### PR TITLE
Fix lagging processing

### DIFF
--- a/DetectiCam.Core/Pipeline/AnalysisResultsChannelConsumer.cs
+++ b/DetectiCam.Core/Pipeline/AnalysisResultsChannelConsumer.cs
@@ -46,7 +46,7 @@ namespace DetectiCam.Core.VideoCapturing
 
                         using Mat inputImage = frame.Image;
 
-                        Logger.LogInformation($"New result received for frame acquired at {frame.Metadata.Timestamp}.");
+                        Logger.LogInformation($"New result received for {frame.Metadata.Info.Id} frame acquired at {frame.Metadata.Timestamp}.");
                         if (analysis.Length > 0 && analysis.Any(o => o.Label == "person"))
                         {
                             Logger.LogInformation($"Person detected for frame acquired at {frame.Metadata.Timestamp}. Sending to result processors");

--- a/DetectiCam.Core/Pipeline/DnnDetectorChannelTransformer.cs
+++ b/DetectiCam.Core/Pipeline/DnnDetectorChannelTransformer.cs
@@ -67,7 +67,7 @@ namespace DetectiCam.Core.Pipeline
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 output.Exception = ae;
-                Logger.LogDebug("DoAnalysis: Exception from analysis task:{message}", ae.Message);
+                Logger.LogError("DoAnalysis: Exception from analysis task:{message}", ae.Message);
             }
 
             return Task.FromResult(output);

--- a/DetectiCam.Core/Pipeline/ISyncTokenProvider.cs
+++ b/DetectiCam.Core/Pipeline/ISyncTokenProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DetectiCam.Core.Pipeline
+{
+    public interface ISyncTokenProvider
+    {
+        int? SyncToken { get; }
+    }
+}

--- a/DetectiCam.Core/Pipeline/ITimestampTrigger.cs
+++ b/DetectiCam.Core/Pipeline/ITimestampTrigger.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DetectiCam.Core.Pipeline
+{
+    public interface ITimestampTrigger
+    {
+        void SetNextTrigger(DateTime timestamp, int triggerId);
+    }
+}

--- a/DetectiCam.Core/Pipeline/MultiChannelMerger.cs
+++ b/DetectiCam.Core/Pipeline/MultiChannelMerger.cs
@@ -34,13 +34,13 @@ namespace DetectiCam.Core.VideoCapturing
             {
                 try
                 {
-                    //using var cts = CancellationTokenSource.CreateLinkedTokenSource(
-                    //    _internalCts.Token, stoppingToken);
-                    //var linkedToken = cts.Token;
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+                        _internalCts.Token, stoppingToken);
+                    var linkedToken = cts.Token;
 
                     while (true)
                     {
-                        stoppingToken.ThrowIfCancellationRequested();
+                        linkedToken.ThrowIfCancellationRequested();
                         List<T> results = new List<T>();
 
                         _logger.LogDebug("Merging frames start batch");
@@ -52,7 +52,7 @@ namespace DetectiCam.Core.VideoCapturing
                                 var curReader = _inputReaders[index];
                                 if (curReader != null)
                                 {
-                                    var result = await curReader.ReadAsync(_internalCts.Token).ConfigureAwait(false);
+                                    var result = await curReader.ReadAsync(linkedToken).ConfigureAwait(false);
                                     results.Add(result);
                                 }
                             }

--- a/DetectiCam.Core/Pipeline/PeriodicTrigger.cs
+++ b/DetectiCam.Core/Pipeline/PeriodicTrigger.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DetectiCam.Core.Pipeline
+{
+    public class PeriodicTrigger : IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly List<ITimestampTrigger> _subjects;
+        private Timer? _timer;
+        private bool disposedValue;
+
+        public PeriodicTrigger(ILogger logger, IEnumerable<ITimestampTrigger> subjects)
+        {
+            _logger = logger;
+            _subjects = new List<ITimestampTrigger>(subjects);
+        }
+
+        public void Start(TimeSpan initialDelay, TimeSpan interval)
+        {
+            int triggerId = 0;
+            // Set up a timer object that will trigger the frame-grab at a regular interval.
+            _timer = new Timer(s /* state */ =>
+            {
+                var now = DateTime.Now;
+                triggerId++;
+                _logger.LogInformation("Timer triggered at:{triggerTimestamp} wit id:{triggerId}", now, triggerId);
+                foreach(var subject in _subjects)
+                {
+                    subject.SetNextTrigger(now, triggerId);
+                }
+            }, null, initialDelay, interval);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _timer?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/DetectiCam.Core/ResultProcessor/CapturePublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/CapturePublisher.cs
@@ -147,11 +147,6 @@ namespace DetectiCam.Core.ResultProcessor
 
             Regex patternMatcher = new Regex(@"(\{.+\})");
 
-            foreach(var m in patternMatcher.Matches(filePattern))
-            {
-                int a = 1;
-            }
-
             var result = patternMatcher.Replace(filePattern, (m) => ts.ToString(m.Value.Trim('{','}'), CultureInfo.InvariantCulture));
 
             return result;

--- a/DetectiCam.Core/VideoCapturing/VideoFrame.cs
+++ b/DetectiCam.Core/VideoCapturing/VideoFrame.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using DetectiCam.Core.Pipeline;
 using OpenCvSharp;
 using System;
 
@@ -21,7 +22,7 @@ namespace DetectiCam.Core.VideoCapturing
 
     /// <summary> A video frame produced by the Framegrabber.
     ///     This class encapsulates the image and metadata. </summary>
-    public class VideoFrame
+    public class VideoFrame : ISyncTokenProvider
     {
         /// <summary> Constructor. </summary>
         /// <param name="image">    The image captured by the camera. </param>
@@ -39,5 +40,9 @@ namespace DetectiCam.Core.VideoCapturing
         /// <summary> Gets the frame's metadata. </summary>
         /// <value> The metadata. </value>
         public VideoFrameContext Metadata { get; }
+
+        public int? TriggerId { get; set; }
+
+        public int? SyncToken => TriggerId;
     }
 }

--- a/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
+++ b/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
@@ -1,7 +1,9 @@
-﻿//#define TRACE_GRABBER
+﻿#define TRACE_GRABBER
 #nullable enable
 
+using DetectiCam.Core.Pipeline;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualBasic;
 using OpenCvSharp;
 using System;
 using System.Diagnostics;
@@ -14,7 +16,7 @@ using System.Threading.Tasks;
 namespace DetectiCam.Core.VideoCapturing
 {
 
-    public class VideoStreamGrabber : IDisposable
+    public class VideoStreamGrabber : IDisposable, ITimestampTrigger
     {
         public string Path { get; }
 
@@ -37,10 +39,25 @@ namespace DetectiCam.Core.VideoCapturing
         public VideoStreamInfo Info { get; }
         public Channel<VideoFrame> OutputChannel { get; }
 
+        private ChannelWriter<VideoFrame> _outputWriter;
+
+
+        private Channel<VideoFrame> _frameBufferChannel = Channel.CreateBounded<VideoFrame>(
+            new BoundedChannelOptions(1)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                AllowSynchronousContinuations = true,
+                SingleReader = true,
+                SingleWriter = true
+            });
+        private ChannelReader<VideoFrame> _frameBufferReader;
+        private ChannelWriter<VideoFrame> _frameBufferWriter;
+
         public VideoStreamGrabber(ILogger logger, VideoStreamInfo streamInfo, Channel<VideoFrame> outputChannel)
         {
             if (logger is null) throw new ArgumentNullException(nameof(logger));
             if (streamInfo is null) throw new ArgumentNullException(nameof(streamInfo));
+            if (outputChannel is null) throw new ArgumentNullException(nameof(outputChannel));
 
             Info = streamInfo;
             Path = streamInfo.Path;
@@ -49,10 +66,17 @@ namespace DetectiCam.Core.VideoCapturing
             IsContinuous = streamInfo.IsContinuous;
             RotateFlags = streamInfo.RotateFlags;
             OutputChannel = outputChannel;
+            _outputWriter = outputChannel.Writer;
+
+            _frameBufferReader = _frameBufferChannel.Reader;
+            _frameBufferWriter = _frameBufferChannel.Writer;
+
 
             _stopping = false;
             _logger = logger;
         }
+
+
 
         [Conditional("TRACE_GRABBER")]
         private void LogTrace(string format, params object[] args)
@@ -90,16 +114,15 @@ namespace DetectiCam.Core.VideoCapturing
 
         public void StartCapturing(TimeSpan publicationInterval, CancellationToken cancellationToken)
         {
-            _executionTask = Task.Run(async () =>
+            _executionTask = Task.Run(() =>
             {
-                var writer = this.OutputChannel.Writer;
                 try
                 {
                     while (!cancellationToken.IsCancellationRequested && !_stopping)
                     {
                         try
                         {
-                            await StartCaptureAsync(publicationInterval, writer, cancellationToken).ConfigureAwait(false);
+                            StartCapture(publicationInterval, cancellationToken);
                         }
 #pragma warning disable CA1031 // Do not catch general exception types
                         catch (Exception ex)
@@ -113,37 +136,49 @@ namespace DetectiCam.Core.VideoCapturing
                 {
                     // We reach this point by breaking out of the while loop. So we must be stopping.
                     _logger.LogInformation($"Capture has stopped for {this.Info.Id}");
-                    writer.TryComplete();
+                    _outputWriter.TryComplete();
                 }
             }, cancellationToken);
         }
 
-        private async Task StartCaptureAsync(TimeSpan publicationInterval, ChannelWriter<VideoFrame> writer, CancellationToken cancellationToken)
+        private int _frameCount = 0;
+        Mat _image1 = new Mat();
+        Mat _image2 = new Mat();
+
+
+        private void StartCapture(TimeSpan publicationInterval, CancellationToken cancellationToken)
         {
             using var reader = this.InitCapture();
             var width = reader.FrameWidth;
             var height = reader.FrameHeight;
-            int frameCount = 0;
             int delayMs = (int)(500.0 / this.Fps);
             int errorCount = 0;
 
-            using Mat imageBuffer = new Mat();
-            Mat publishedImage;
-
-            var nextpublicationTime = DateTime.Now;
             while (!cancellationToken.IsCancellationRequested && !_stopping)
             {
+                _frameCount++;
+
+                Mat imageBuffer = (_frameCount % 2 == 0)? _image1: _image2;
+                bool succesfullGrab;
+
                 var startTime = DateTime.Now;
                 // Grab single frame.
                 var timestamp = DateTime.Now;
 
                 bool success = reader.Read(imageBuffer);
-                frameCount++;
 
                 var endTime = DateTime.Now;
                 LogTrace("Producer: frame-grab took {0} ms", (endTime - startTime).Milliseconds);
 
-                if (!success || imageBuffer.Empty())
+                succesfullGrab = success && !imageBuffer.Empty();
+
+                if (succesfullGrab)
+                {
+                    var ctx = new VideoFrameContext(timestamp, _frameCount, this.Info);
+                    var videoFrame = new VideoFrame(imageBuffer, ctx);
+                    _frameBufferWriter.TryWrite(videoFrame);
+                }
+                else
                 {
                     // If we've reached the end of the video, stop here.
                     if (IsContinuous)
@@ -172,22 +207,8 @@ namespace DetectiCam.Core.VideoCapturing
                         break;
                     }
                 }
-                else if (timestamp > nextpublicationTime)
-                {
-                    LogTrace("Producer: create frame to publish:");
-                    nextpublicationTime = timestamp + publicationInterval;
-
-                    publishedImage = PreprocessImage(imageBuffer);
-
-                    // Package the image for submission.
-                    VideoFrameContext meta = new VideoFrameContext(timestamp, frameCount, this.Info);
-                    VideoFrame vframe = new VideoFrame(publishedImage, meta);
-
-                    LogTrace("Producer: do publishing");
-                    var writeResult = writer.TryWrite(vframe);
-                }
-                //Thread.Sleep(delayMs);
-                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+                Thread.Sleep(delayMs);
+                //await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -234,6 +255,8 @@ namespace DetectiCam.Core.VideoCapturing
                     StopProcessingAsync()?.Wait(2000);
                     _videoCapture?.Dispose();
                     _videoCapture = null;
+                    _image1?.Dispose();
+                    _image2?.Dispose();
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
@@ -254,6 +277,25 @@ namespace DetectiCam.Core.VideoCapturing
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        public void SetNextTrigger(DateTime timestamp, int triggerId)
+        {
+            if (_frameBufferReader.TryRead(out var frame))
+            {
+                Mat imageToPublish = PreprocessImage(frame.Image);
+
+                // Package the image for submission.
+                VideoFrame vframe = new VideoFrame(imageToPublish, frame.Metadata);
+                vframe.TriggerId = triggerId;
+
+                _logger.LogDebug($"Producer: do publishing of frame {frame.Metadata.Timestamp}; {this.Info.Id}; of trigger: {triggerId}");
+                var writeResult = _outputWriter.TryWrite(vframe);
+            }
+            else
+            {
+                _logger.LogWarning("No frame available to publish");
+            }
         }
     }
 }

--- a/DetectiCam.CoreTests/Pipeline/SyncedMultiChannelMergerTests.cs
+++ b/DetectiCam.CoreTests/Pipeline/SyncedMultiChannelMergerTests.cs
@@ -1,0 +1,202 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DetectiCam.Core.VideoCapturing;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Moq;
+using DetectiCam.Core.Pipeline;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace DetectiCam.Core.VideoCapturing.Tests
+{
+    [TestClass()]
+    public class SyncedMultiChannelMergerTests
+    {
+        public class SyncItem : ISyncTokenProvider
+        {
+            public int Value { get; set; }
+            public int? TriggerId { get; set; }
+
+            public int? SyncToken => TriggerId;
+        }
+    
+
+        CancellationTokenSource _cts;
+
+        Channel<SyncItem> _firstInput;
+        Channel<SyncItem> _secondInput;
+        Channel<IList<SyncItem>> _output;
+        ILogger _logger;
+        List<ChannelReader<SyncItem>> _inputs;
+
+        SyncedMultiChannelMerger<SyncItem> _sut;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _cts = new CancellationTokenSource();
+
+            _firstInput = Channel.CreateBounded<SyncItem>(5);
+            _secondInput = Channel.CreateBounded<SyncItem>(5);
+            _output = Channel.CreateUnbounded<IList<SyncItem>>();
+
+            //or use this short equivalent 
+            _logger = Mock.Of<ILogger>();
+
+            _inputs = new List<ChannelReader<SyncItem>>
+            {
+                _firstInput.Reader,
+                _secondInput.Reader
+            };
+
+            _sut = new SyncedMultiChannelMerger<SyncItem>(_inputs, _output.Writer, _logger);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _cts.Dispose();
+            _sut.Dispose();
+        }
+
+
+        [TestMethod()]
+        public async Task InSyncProcessingTest()
+        {
+            var task = _sut.ExecuteProcessingAsync(_cts.Token);
+
+            int triggerId = 0;
+
+            for (int x = 1; x <= 5; x++)
+            {
+                triggerId++;
+                await _firstInput.Writer.WriteAsync(new SyncItem() { TriggerId = triggerId, Value = x });
+            }
+            _firstInput.Writer.Complete();
+
+            triggerId = 0;
+            for (int y = 5; y >= 1; y--)
+            {
+                triggerId++;
+                await _secondInput.Writer.WriteAsync(new SyncItem() { TriggerId = triggerId, Value = y });
+            }
+            _secondInput.Writer.Complete();
+
+            int resultCount = 0;
+            await foreach (var result in _output.Reader.ReadAllAsync(_cts.Token))
+            {
+                Assert.AreEqual(2, result.Count);
+                Assert.AreEqual(6, result.Select(x=>x.Value).Sum());
+                resultCount++;
+            }
+
+            await task;
+            Assert.AreEqual(5, resultCount);
+        }
+
+        [TestMethod()]
+        public async Task OutOfSync_FirstHighest_ProcessingTest()
+        {
+            var task = _sut.ExecuteProcessingAsync(_cts.Token);
+
+            int triggerId = 1;
+
+            for (int x = 2; x <= 5; x++)
+            {
+                triggerId++;
+                await _firstInput.Writer.WriteAsync(new SyncItem() { TriggerId = triggerId, Value = x });
+            }
+            _firstInput.Writer.Complete();
+
+            triggerId = 0;
+            for (int y = 5; y >= 1; y--)
+            {
+                triggerId++;
+                await _secondInput.Writer.WriteAsync(new SyncItem() { TriggerId = triggerId, Value = y });
+            }
+            _secondInput.Writer.Complete();
+
+            //Expected:
+            //- first result of second stream is dropped to get into sync.
+            //- four results will come out that are in sync
+
+            int resultCount = 0;
+            await foreach (var result in _output.Reader.ReadAllAsync(_cts.Token))
+            {
+                Assert.AreEqual(2, result.Count);
+                Assert.AreEqual(6, result.Select(x => x.Value).Sum());
+                resultCount++;
+            }
+
+            await task;
+            Assert.AreEqual(4, resultCount);
+        }
+
+        [TestMethod()]
+        public async Task OutOfSync_SecondHighest_ProcessingTest()
+        {
+            var task = _sut.ExecuteProcessingAsync(_cts.Token);
+
+            int triggerId = 0;
+
+            for (int x = 1; x <= 5; x++)
+            {
+                triggerId++;
+                await _firstInput.Writer.WriteAsync(new SyncItem() { TriggerId = triggerId, Value = x });
+            }
+            _firstInput.Writer.Complete();
+
+            triggerId = 1;
+            for (int y = 4; y >= 1; y--)
+            {
+                triggerId++;
+                await _secondInput.Writer.WriteAsync(new SyncItem() { TriggerId = triggerId, Value = y });
+            }
+            _secondInput.Writer.Complete();
+
+            //Expected:
+            //- first result of first stream is dropped to get into sync.
+            //- four results will come out that are in sync
+
+            int resultCount = 0;
+            await foreach (var result in _output.Reader.ReadAllAsync(_cts.Token))
+            {
+                Assert.AreEqual(2, result.Count);
+                Assert.AreEqual(6, result.Select(x => x.Value).Sum());
+                resultCount++;
+            }
+
+            await task;
+            Assert.AreEqual(4, resultCount);
+        }
+
+
+        //[TestMethod()]
+        //public void SyncedMultiChannelMergerTest()
+        //{
+        //    Assert.Fail();
+        //}
+
+        //[TestMethod()]
+        //public void ExecuteProcessingAsyncTest()
+        //{
+        //    Assert.Fail();
+        //}
+
+        //[TestMethod()]
+        //public void StopProcessingAsyncTest()
+        //{
+        //    Assert.Fail();
+        //}
+
+        //[TestMethod()]
+        //public void DisposeTest()
+        //{
+        //    Assert.Fail();
+        //}
+    }
+}


### PR DESCRIPTION
Created a external timetrigger towards all video sources. This way captures will be in sync.
Because not all video streams are initialized at the same time, in the beginning published frames can be out of sync.
To counter this, the ChannelMerger has been expanded with the ability to sync the input streams based on the trigger id.
It will fast-forward each stream to sync up with the newest stream, and only publish a batch that is complete. 
During the fast-forwarding, the "stale" frames are dropped and not run through analysis anymore.

Normally, this process should only happen during startup. However, something similar could happen if for some reason one of the videostreams get restarted while the others are not.