### PR TITLE
Add multi class configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,7 @@ paket-files/
 YoloData
 appsettings.Development*.json
 docker-test
+DetectiCam/captures
 
 #Sonar
 .sonarqube

--- a/DetectiCam.Core/Common/ConfigurableService.cs
+++ b/DetectiCam.Core/Common/ConfigurableService.cs
@@ -18,9 +18,16 @@ namespace DetectiCam.Core.Common
 
             Logger = logger;
 
+            Options = GetValidatedOptions(options);
+        }
+
+        protected T GetValidatedOptions<T>(IOptions<T> options) where T: class,new()
+        {
+            if (options is null) throw new ArgumentNullException(nameof(options));
+
             try
             {
-                Options = options.Value;
+                return options.Value;
             }
             catch (OptionsValidationException ex)
             {

--- a/DetectiCam.Core/Common/TagReplacer.cs
+++ b/DetectiCam.Core/Common/TagReplacer.cs
@@ -1,0 +1,69 @@
+﻿using DetectiCam.Core.VideoCapturing;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DetectiCam.Core.Common
+{
+    public static class TagReplacer
+    {
+        private static readonly Regex _patternMatcher = new Regex(@"(\{.+\})", RegexOptions.Compiled);
+
+        public static string ReplaceTags(string pattern, VideoFrame frame)
+        {
+            if (pattern is null) throw new ArgumentNullException(nameof(pattern));
+            if (frame is null) throw new ArgumentNullException(nameof(frame));
+
+            var result = ReplaceTsToken(pattern, frame);
+            result = ReplaceVsIdToken(result, frame);
+            result = ReplaceDetectedObjectsToken(result, frame);
+            result = ReplaceDateTimeTokens(result, frame);
+
+            return result;
+        }
+
+        private static string GetTimestampedSortable(VideoFrameContext metaData)
+        {
+            return $"{metaData.Timestamp:yyyyMMddTHHmmss}";
+        }
+
+        private static string ReplaceTsToken(string filePattern, VideoFrame frame)
+        {
+            string ts = GetTimestampedSortable(frame.Metadata);
+
+            return filePattern.Replace("{ts}", ts, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ReplaceVsIdToken(string filePattern, VideoFrame frame)
+        {
+            return filePattern.Replace("{vsid}", frame.Metadata.Info.Id, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ReplaceDetectedObjectsToken(string filePattern, VideoFrame frame)
+        {
+            if (filePattern.Contains("{dobj}", StringComparison.OrdinalIgnoreCase))
+            {
+                var objectList = String.Join(',', frame.Metadata.AnalysisResult.Select(d => d.Label).Distinct());
+
+                return filePattern.Replace("{dobj}", objectList, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                return filePattern;
+            }
+        }
+
+        private static string ReplaceDateTimeTokens(string filePattern, VideoFrame frame)
+        {
+            var ts = frame.Metadata.Timestamp;
+
+            var result = _patternMatcher.Replace(filePattern, (m) => ts.ToString(m.Value.Trim('{', '}'), CultureInfo.CurrentCulture));
+
+            return result;
+        }
+
+    }
+}

--- a/DetectiCam.Core/Common/TokenReplacer.cs
+++ b/DetectiCam.Core/Common/TokenReplacer.cs
@@ -8,11 +8,11 @@ using System.Text.RegularExpressions;
 
 namespace DetectiCam.Core.Common
 {
-    public static class TagReplacer
+    public static class TokenReplacer
     {
         private static readonly Regex _patternMatcher = new Regex(@"(\{.+\})", RegexOptions.Compiled);
 
-        public static string ReplaceTags(string pattern, VideoFrame frame)
+        public static string ReplaceTokens(string pattern, VideoFrame frame)
         {
             if (pattern is null) throw new ArgumentNullException(nameof(pattern));
             if (frame is null) throw new ArgumentNullException(nameof(frame));
@@ -30,37 +30,37 @@ namespace DetectiCam.Core.Common
             return $"{metaData.Timestamp:yyyyMMddTHHmmss}";
         }
 
-        private static string ReplaceTsToken(string filePattern, VideoFrame frame)
+        private static string ReplaceTsToken(string pattern, VideoFrame frame)
         {
             string ts = GetTimestampedSortable(frame.Metadata);
 
-            return filePattern.Replace("{ts}", ts, StringComparison.OrdinalIgnoreCase);
+            return pattern.Replace("{ts}", ts, StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string ReplaceVsIdToken(string filePattern, VideoFrame frame)
+        private static string ReplaceVsIdToken(string pattern, VideoFrame frame)
         {
-            return filePattern.Replace("{vsid}", frame.Metadata.Info.Id, StringComparison.OrdinalIgnoreCase);
+            return pattern.Replace("{vsid}", frame.Metadata.Info.Id, StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string ReplaceDetectedObjectsToken(string filePattern, VideoFrame frame)
+        private static string ReplaceDetectedObjectsToken(string pattern, VideoFrame frame)
         {
-            if (filePattern.Contains("{dobj}", StringComparison.OrdinalIgnoreCase))
+            if (pattern.Contains("{dobj}", StringComparison.OrdinalIgnoreCase))
             {
                 var objectList = String.Join(',', frame.Metadata.AnalysisResult.Select(d => d.Label).Distinct());
 
-                return filePattern.Replace("{dobj}", objectList, StringComparison.OrdinalIgnoreCase);
+                return pattern.Replace("{dobj}", objectList, StringComparison.OrdinalIgnoreCase);
             }
             else
             {
-                return filePattern;
+                return pattern;
             }
         }
 
-        private static string ReplaceDateTimeTokens(string filePattern, VideoFrame frame)
+        private static string ReplaceDateTimeTokens(string pattern, VideoFrame frame)
         {
             var ts = frame.Metadata.Timestamp;
 
-            var result = _patternMatcher.Replace(filePattern, (m) => ts.ToString(m.Value.Trim('{', '}'), CultureInfo.CurrentCulture));
+            var result = _patternMatcher.Replace(pattern, (m) => ts.ToString(m.Value.Trim('{', '}'), CultureInfo.CurrentCulture));
 
             return result;
         }

--- a/DetectiCam.Core/Detection/DetectionOptions.cs
+++ b/DetectiCam.Core/Detection/DetectionOptions.cs
@@ -1,0 +1,12 @@
+﻿
+namespace DetectiCam.Core.Detection
+{
+    public class DetectionOptions
+    {
+        public const string Detection = "detection";
+
+        public float DetectionThreshold { get; set; } = 0.5f;
+
+        public ObjectWhiteList ObjectWhiteList { get; } = new ObjectWhiteList();
+    }
+}

--- a/DetectiCam.Core/Detection/IBatchedDnnDetector.cs
+++ b/DetectiCam.Core/Detection/IBatchedDnnDetector.cs
@@ -6,7 +6,7 @@ namespace DetectiCam.Core.Detection
 {
     public interface IBatchedDnnDetector : IDisposable
     {
-        public IList<DnnDetectedObject[]> ClassifyObjects(IList<Mat> images);
+        public IList<DnnDetectedObject[]> ClassifyObjects(IList<Mat> images, float detectionThreshold);
         public void Initialize();
     }
 }

--- a/DetectiCam.Core/Detection/ObjectWhiteList.cs
+++ b/DetectiCam.Core/Detection/ObjectWhiteList.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.ObjectModel;
+
+namespace DetectiCam.Core.Detection
+{
+    public class ObjectWhiteList : Collection<string>
+    {
+    }
+}

--- a/DetectiCam.Core/Detection/YoloBatchedDnnDetector.cs
+++ b/DetectiCam.Core/Detection/YoloBatchedDnnDetector.cs
@@ -21,7 +21,6 @@ namespace DetectiCam.Core.Detection
         private readonly Mat[] outs;
         private readonly string[] _outNames;
 
-        private const float threshold = 0.5f;       //for confidence 
         private const float nmsThreshold = 0.3f;    //threshold for nms
 
         public YoloBatchedDnnDetector(ILogger<YoloBatchedDnnDetector> logger, IConfiguration configuration)
@@ -69,14 +68,14 @@ namespace DetectiCam.Core.Detection
                 dummy1,
                 dummy2
             };
-            ClassifyObjects(images);
+            ClassifyObjects(images, 0.5f);
             _logger.LogInformation("Detector initalized");
         }
 
         private const double scaleFactor = 1.0 / 255;
         private readonly Size scaleSize = new Size(320, 320);
 
-        public IList<DnnDetectedObject[]> ClassifyObjects(IList<Mat> images)
+        public IList<DnnDetectedObject[]> ClassifyObjects(IList<Mat> images, float detectionThreshold)
         {
             if (images is null) throw new ArgumentNullException(nameof(images));
 
@@ -93,11 +92,11 @@ namespace DetectiCam.Core.Detection
 
             if (images.Count == 1)
             {
-                return ExtractYoloSingleResults(outs, images[0], threshold, nmsThreshold);
+                return ExtractYoloSingleResults(outs, images[0], detectionThreshold, nmsThreshold);
             }
             else
             {
-                return ExtractYoloBatchedResults(outs, images, threshold, nmsThreshold);
+                return ExtractYoloBatchedResults(outs, images, detectionThreshold, nmsThreshold);
             }
         }
 

--- a/DetectiCam.Core/Pipeline/DnnDetectorChannelTransformer.cs
+++ b/DetectiCam.Core/Pipeline/DnnDetectorChannelTransformer.cs
@@ -17,8 +17,10 @@ namespace DetectiCam.Core.Pipeline
     {
         private readonly IBatchedDnnDetector _detector;
         private readonly IHeartbeatReporter _heartbeatReporter;
+        private readonly float _detectionThreshold;
 
         public DnnDetectorChannelTransformer(IBatchedDnnDetector detector,
+            float detectionThreshold,
             ChannelReader<IList<VideoFrame>> inputReader,
             ChannelWriter<IList<VideoFrame>> outputWriter,
             IHeartbeatReporter heartbeatReporter,
@@ -28,8 +30,8 @@ namespace DetectiCam.Core.Pipeline
             if (detector is null) throw new ArgumentNullException(nameof(detector));
             if (heartbeatReporter is null) throw new ArgumentNullException(nameof(heartbeatReporter));
 
+            _detectionThreshold = detectionThreshold;
             _heartbeatReporter = heartbeatReporter;
-
             _detector = detector;
             _detector.Initialize();
         }
@@ -52,7 +54,7 @@ namespace DetectiCam.Core.Pipeline
                 {
                     _stopwatch.Restart();
 
-                    result = _detector.ClassifyObjects(images);
+                    result = _detector.ClassifyObjects(images, _detectionThreshold);
 
                     _stopwatch.Stop();
                     Logger.LogInformation("Classifiy-objects ms:{classifyDuration} for {imageCount} images", _stopwatch.ElapsedMilliseconds, images.Count);

--- a/DetectiCam.Core/ResultProcessor/BoundingBox.cs
+++ b/DetectiCam.Core/ResultProcessor/BoundingBox.cs
@@ -1,0 +1,26 @@
+﻿using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DetectiCam.Core.ResultProcessor
+{
+    public class BoundingBox
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+
+        public static BoundingBox FromRect2D(Rect2d input)
+        {
+            return new BoundingBox()
+            {
+                X = (int)input.Left,
+                Y = (int)input.Top,
+                Width = (int)input.Width,
+                Height = (int)input.Height
+            };
+        }
+    }
+}

--- a/DetectiCam.Core/ResultProcessor/CapturePublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/CapturePublisher.cs
@@ -84,7 +84,7 @@ namespace DetectiCam.Core.ResultProcessor
             Logger.LogInformation("Detected: {detectionstats}", stats);
 
 
-            var filename = TagReplacer.ReplaceTags(Options.CapturePattern, frame);
+            var filename = TokenReplacer.ReplaceTokens(Options.CapturePattern, frame);
 
             var filePath = Path.Combine(_captureRootPath, filename);
             EnsureDirectoryPath(filePath);

--- a/DetectiCam.Core/ResultProcessor/DetectedObject.cs
+++ b/DetectiCam.Core/ResultProcessor/DetectedObject.cs
@@ -1,0 +1,28 @@
+﻿using DetectiCam.Core.Detection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DetectiCam.Core.ResultProcessor
+{
+    public class DetectedObject
+    {
+        public int Index { get; set; }
+        public string? Label { get; set; }
+        public float Probability { get; set; }
+        public BoundingBox? BoundingBox { get; set; }
+
+        public static DetectedObject ConvertFrom(DnnDetectedObject dnnDetectedObject)
+        {
+            if (dnnDetectedObject is null) throw new ArgumentNullException(nameof(dnnDetectedObject));
+
+            return new DetectedObject()
+            {
+                BoundingBox = BoundingBox.FromRect2D(dnnDetectedObject.BoundingBox),
+                Index = dnnDetectedObject.Index,
+                Label = dnnDetectedObject.Label,
+                Probability = dnnDetectedObject.Probability
+            };
+        }
+    }
+}

--- a/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
@@ -63,12 +63,19 @@ namespace DetectiCam.Core.ResultProcessor
 
                 var output = new { detection = true,
                     detectedObjects = Options.IncludeDetectedObjects ? 
-                        frame.Metadata.AnalysisResult.Select(
-                            (dob,i) => DetectedObject.ConvertFrom(dob)).ToList()
+                        frame.Metadata.AnalysisResult
+                            .OrderByDescending(r => r.Probability)
+                            .Take(Options.TopDetectedObjectsLimit)
+                            .Select((dob,i) => DetectedObject.ConvertFrom(dob))
+                            .ToList()
                         : null 
                     };
 
-                string strValue = JsonSerializer.Serialize(output); //, "{ \"detection\" : true }";
+                string strValue = JsonSerializer.Serialize(output,
+                    new JsonSerializerOptions()
+                    {
+                        IgnoreNullValues = true
+                    });
 
                 string topic = $"{_topicPrefix}detect-i-cam/{frame.Metadata.Info.Id}/state";
 

--- a/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/MqttPublisher.cs
@@ -4,7 +4,9 @@ using DetectiCam.Core.VideoCapturing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using uPLibrary.Networking.M2Mqtt;
@@ -59,7 +61,15 @@ namespace DetectiCam.Core.ResultProcessor
             {
                 if (frame is null) throw new ArgumentNullException(nameof(frame));
 
-                string strValue = "{ \"detection\" : true }";
+                var output = new { detection = true,
+                    detectedObjects = Options.IncludeDetectedObjects ? 
+                        frame.Metadata.AnalysisResult.Select(
+                            (dob,i) => DetectedObject.ConvertFrom(dob)).ToList()
+                        : null 
+                    };
+
+                string strValue = JsonSerializer.Serialize(output); //, "{ \"detection\" : true }";
+
                 string topic = $"{_topicPrefix}detect-i-cam/{frame.Metadata.Info.Id}/state";
 
                 // publish a message on "/home/temperature" topic with QoS 2 

--- a/DetectiCam.Core/ResultProcessor/MqttPublisherOptions.cs
+++ b/DetectiCam.Core/ResultProcessor/MqttPublisherOptions.cs
@@ -16,5 +16,6 @@ namespace DetectiCam.Core.Detection
         public string? TopicPrefix { get; set; }
         public string? ClientId { get; set; }
         public bool IncludeDetectedObjects { get; set; }
+        public int TopDetectedObjectsLimit { get; set; } = 3;
     }
 }

--- a/DetectiCam.Core/ResultProcessor/MqttPublisherOptions.cs
+++ b/DetectiCam.Core/ResultProcessor/MqttPublisherOptions.cs
@@ -15,5 +15,6 @@ namespace DetectiCam.Core.Detection
         public string? Password { get; set; }
         public string? TopicPrefix { get; set; }
         public string? ClientId { get; set; }
+        public bool IncludeDetectedObjects { get; set; }
     }
 }

--- a/DetectiCam.Core/ResultProcessor/WebhookPublisher.cs
+++ b/DetectiCam.Core/ResultProcessor/WebhookPublisher.cs
@@ -34,7 +34,7 @@ namespace DetectiCam.Core.ResultProcessor
             {
                 _logger.LogInformation("Webhook notify for {streamId}", frame.Metadata.Info.Id);
 
-                var replacedUrl = TagReplacer.ReplaceTags(urlTemplate, frame);
+                var replacedUrl = TokenReplacer.ReplaceTokens(urlTemplate, frame);
                 try
                 {
                     var uri = new Uri(replacedUrl);

--- a/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
+++ b/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
@@ -42,7 +42,7 @@ namespace DetectiCam.Core.VideoCapturing
             new BoundedChannelOptions(1)
             {
                 FullMode = BoundedChannelFullMode.DropOldest,
-                AllowSynchronousContinuations = true,
+                AllowSynchronousContinuations = false,
                 SingleReader = true,
                 SingleWriter = true
             });

--- a/DetectiCam.Core/VideoCapturing/VideoStreamInfo.cs
+++ b/DetectiCam.Core/VideoCapturing/VideoStreamInfo.cs
@@ -1,7 +1,6 @@
-﻿#nullable enable
-
-using OpenCvSharp;
+﻿using OpenCvSharp;
 using System;
+using DetectiCam.Core.Detection;
 
 namespace DetectiCam.Core.VideoCapturing
 {
@@ -33,8 +32,10 @@ namespace DetectiCam.Core.VideoCapturing
             }
         }
 
-        public Uri? CallbackUrl { get; set; }
+        public string? CallbackUrl { get; set; }
 
         public RotateFlags? RotateFlags { get; set; }
+
+        public ObjectWhiteList AdditionalObjectWhitelist { get; } = new ObjectWhiteList();
     }
 }

--- a/DetectiCam/Program.cs
+++ b/DetectiCam/Program.cs
@@ -40,6 +40,10 @@ namespace DetectiCam
                 services.AddOptions<VideoStreamsOptions>()
                     .Bind(hostContext.Configuration.GetSection(VideoStreamsOptions.VideoStreams))
                     .ValidateDataAnnotations();
+                services.AddOptions<DetectionOptions>()
+                    .Bind(hostContext.Configuration.GetSection(DetectionOptions.Detection))
+                    .ValidateDataAnnotations();
+
 
                 var generateConfig = hostContext.Configuration.GetValue<bool>("gen-config");
                 if (generateConfig)

--- a/DetectiCam/Properties/launchSettings.json
+++ b/DetectiCam/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
     "CoreConsole": {
-      "commandName": "Executable",
+      "commandName": "Project",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       }

--- a/DetectiCam/appsettings.template.json
+++ b/DetectiCam/appsettings.template.json
@@ -1,30 +1,38 @@
 ﻿{
-  //"video-streams": [ // add a list of videostreams to be monitored.
-  //  {
-  //    "id": "<identifier>",
-  //    "path": "rtsp://<user>:<password>@<host>:<port>/<subpath>", // check your camera documentation. Be user to use Url encoding on the password if it contains special characters
-  //    "rotate": "Rotate90Clockwise", //optional: leave out if no rotation is need
-  //    "fps": 15
-  //  }
-  //],
-  //"yolo3": { // location of datafiles for the yolov3 detector.
-  //  "rootPath": "/yolo-data",
-  //  "namesFile": "coco.names",
-  //  "configFile": "yolov3.cfg",
-  //  "weightsFile": "yolov3.weights"
-  //},
-  //"mqtt-publisher": {
-  //  "enabled": true,
-  //  "server": "nuc.home",
-  //  "port": 1883,
-  //  "username": "myuser",
-  //  "password": "passwd",
-  //  "topicPrefix": "home",
-  //  "clientId": "detecticam"
-  //},
-  //"capture-publisher": {
-  //  "enabled": true,
-  //  "captureRootDir" : "./captures",
-  //  "capturePattern" : "{yyyy-MM-dd}/{streamId}-{ts}.jpg"
-  //}
+  "video-streams": [ // add a list of videostreams to be monitored.
+    {
+      "id": "<identifier>",
+      "path": "rtsp://<user>:<password>@<host>:<port>/<subpath>", // check your camera documentation. Be user to use Url encoding on the password if it contains special characters
+      "rotate": "Rotate90Clockwise", //optional: leave out if no rotation is need
+      "fps": 15,
+      "additionalObjectWhitelist": [ "cat" ],
+      "callbackUrl": "http:\/\/<host>\/test?x={dobj}"
+    }
+  ],
+  "detection": {
+    "detectionThreshold": 0.5,
+    "objectWhitelist": [ "person", "car" ]
+  },
+  "yolo3": { // location of datafiles for the yolov3 detector.
+    "rootPath": "/yolo-data",
+    "namesFile": "coco.names",
+    "configFile": "yolov3.cfg",
+    "weightsFile": "yolov3.weights"
+  },
+  "mqtt-publisher": {
+    "enabled": true,
+    "server": "nuc.home",
+    "port": 1883,
+    "username": "myuser",
+    "password": "passwd",
+    "topicPrefix": "home",
+    "clientId": "detecticam",
+    "includeDetectedObjects": false,
+    "topDetectedObjectsLimit": 3
+  },
+  "capture-publisher": {
+    "enabled": true,
+    "captureRootDir" : "./captures",
+    "capturePattern" : "{yyyy-MM-dd}/{streamId}-{ts}.jpg"
+  }
 }


### PR DESCRIPTION
- Added the ability to configure classes to detect on, and the minimum probability threshold.
- The information of detections can now be used in callbackurls.
- Mqtt messages can now publish details on detections for further processing.

Check the [README.md](https://github.com/RaimondB/Detecticam/blob/add-multi-class-configuration/README.md) for all new functionality.