### PR TITLE
Fix ROI processing to be robust when the ROI is out of bounds of the image

### DIFF
--- a/DetectiCam.Core/Common/MathExtensions.cs
+++ b/DetectiCam.Core/Common/MathExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DetectiCam.Core.Common
+{
+    public static class MathExtensions
+    {
+        public static T CropInRange<T>(this T value, T lowerBound, T upperBound) where T : IComparable<T>
+        {
+            if (value.CompareTo(lowerBound) < 0)
+            {
+                return lowerBound;
+            }
+            else if (value.CompareTo(upperBound) > 0)
+            {
+                return upperBound;
+            }
+            else
+            {
+                return value;
+            }
+        }
+    }
+}

--- a/DetectiCam.Core/Detection/Region.cs
+++ b/DetectiCam.Core/Detection/Region.cs
@@ -1,4 +1,6 @@
 ﻿
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace DetectiCam.Core.Detection
 {
     public class Region
@@ -7,5 +9,10 @@ namespace DetectiCam.Core.Detection
         public int Top { get; set; }
         public int Right { get; set; }
         public int Bottom { get; set; }
+
+        public override string ToString()
+        {
+            return $"{{Left:{Left}, Top:{Top}, Right:{Right}, Bottom:{Bottom}}}";
+        }
     }
 }

--- a/DetectiCam.Core/Visualization/Visualizer.cs
+++ b/DetectiCam.Core/Visualization/Visualizer.cs
@@ -1,27 +1,12 @@
 ﻿using DetectiCam.Core.Detection;
 using OpenCvSharp;
 using System;
+using DetectiCam.Core.Common;
 
 namespace DetectiCam.Core.Visualization
 {
     public static class Visualizer
     {
-        private static T CropInRange<T>(this T value, T lowerBound, T upperBound) where T : IComparable<T>
-        {
-            if (value.CompareTo(lowerBound) < 0)
-            {
-                return lowerBound;
-            }
-            else if (value.CompareTo(upperBound) > 0)
-            {
-                return upperBound;
-            }
-            else
-            {
-                return value;
-            }
-        }
-
         public static Mat AnnotateImage(Mat orgImage, DnnDetectedObject[] detectedObjects)
         {
             if (detectedObjects == null) throw new ArgumentNullException(nameof(detectedObjects));


### PR DESCRIPTION
Instead of throwing an exception, when the region does not fit within the frame, detect-i-cam will now crop the ROI within the bounds and report a warning about misconfiguration.
