### PR TITLE
build(dotnet): Change to .NET5 repo location

### DIFF
--- a/DetectiCam/Dockerfile
+++ b/DetectiCam/Dockerfile
@@ -1,10 +1,10 @@
-FROM raimondb/opencv-dotnet-runtime-deps:0.6.0 AS base
+FROM raimondb/opencv-dotnet-runtime-deps:0.7.0 AS base
 COPY --from=raimondb/yolov3-data ["yolov3.weights", "yolov3.cfg", "coco.names", "/yolo-data/"]
 RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.405-bionic AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1.405-bionic-arm64v8 AS build
 WORKDIR /src
 COPY ["DetectiCam/DetectiCam.csproj", "DetectiCam/"]
 COPY ["DetectiCam.Core/DetectiCam.Core.csproj", "DetectiCam.Core/"]

--- a/DetectiCam/Program.cs
+++ b/DetectiCam/Program.cs
@@ -70,11 +70,11 @@ namespace DetectiCam
             })
             .ConfigureLogging(logging =>
             {
-                logging.AddConsole(c =>
-                {
-                    c.TimestampFormat = "[HH:mm:ss.fff] ";
-                    c.IncludeScopes = false;
-                });
+                _ = logging.AddSimpleConsole(c =>
+                  {
+                      c.TimestampFormat = "[HH:mm:ss.fff] ";
+                      c.IncludeScopes = false;
+                  });
             });
 
         private static void ConfigureConfigDir(HostBuilderContext hostingContext, IConfigurationBuilder config)


### PR DESCRIPTION
Using the new repo locations used for .NET5. Upgrade to .NET not yet possible
because opencv first needs to support Ubuntu 20.