### PR TITLE
fix(detecticam): :arrow_down: Downgrade OpenCV lib to fix memory issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,14 +19,8 @@ updates:
             - "MSTest.*"
             - "Microsoft.NET.Test.*"
   ignore:
-    - dependency-name: "OpenCvSharp4"
-      versions: ["4.x"]
-    - dependency-name: "OpenCvSharp4_.runtime.ubuntu.20.04-x64"
-      versions: ["4.x"]
-    - dependency-name: "OpenCvSharp4.runtime.win"
-      versions: ["4.x"]
-    - dependency-name: "OpenCvSharp4.runtime.linux-arm"
-      versions: ["4.x"]
+    - dependency-name: "OpenCvSharp4*"
+      versions: ["4.*"]
 
   # ignore:
   #     # Ignore .NET 7 related version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,15 @@ updates:
           patterns:
             - "MSTest.*"
             - "Microsoft.NET.Test.*"
+  ignore:
+    - dependency-name: "OpenCvSharp4"
+      versions: ["4.x"]
+    - dependency-name: "OpenCvSharp4_.runtime.ubuntu.20.04-x64"
+      versions: ["4.x"]
+    - dependency-name: "OpenCvSharp4.runtime.win"
+      versions: ["4.x"]
+    - dependency-name: "OpenCvSharp4.runtime.linux-arm"
+      versions: ["4.x"]
 
   # ignore:
   #     # Ignore .NET 7 related version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,17 @@ updates:
     time: "04:00"
   open-pull-requests-limit: 10
   groups:
-       ms-extensions-dependencies:
-          patterns:
-            - "Microsoft.Extensions.*"
-       ms-platform-dependencies:
-          patterns:
-            - "Microsoft.NetCore.Platforms"
-            - "Microsoft.CodeAnalysis.*"
-      ms-test-dependencies:
-          patterns:
-            - "MSTest.*"
-            - "Microsoft.NET.Test.*"
+    ms-extensions-dependencies:
+      patterns:
+        - "Microsoft.Extensions.*"
+    ms-platform-dependencies:
+      patterns:
+        - "Microsoft.NetCore.Platforms"
+        - "Microsoft.CodeAnalysis.*"
+    ms-test-dependencies:
+      patterns:
+        - "MSTest.*"
+        - "Microsoft.NET.Test.*"
   ignore:
     - dependency-name: "OpenCvSharp4*"
       versions: ["4.*"]

--- a/DetectiCam.Core/DetectiCam.Core.csproj
+++ b/DetectiCam.Core/DetectiCam.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -24,10 +24,10 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="7.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="OpenCvSharp4" Version="4.7.0.20230115" />
+    <PackageReference Include="OpenCvSharp4" Version="4.6.0.20220608" />
     <PackageReference Include="OpenCvSharp4_.runtime.ubuntu.20.04-x64" Version="4.7.0.20230115" />
-    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.7.0.20230115" />
-    <PackageReference Include="OpenCvSharp4.runtime.linux-arm" Version="4.7.0.20230115" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.6.0.20220608" />
+    <PackageReference Include="OpenCvSharp4.runtime.linux-arm" Version="4.6.0.20220608" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
   </ItemGroup>

--- a/DetectiCam.Core/Pipeline/MultiStreamBatchedProcessorPipeline.cs
+++ b/DetectiCam.Core/Pipeline/MultiStreamBatchedProcessorPipeline.cs
@@ -93,19 +93,26 @@ namespace DetectiCam.Core.VideoCapturing
 
         public async Task StartCapturingAllStreamsAsync(CancellationToken cancellationToken)
         {
-            Logger.LogInformation("Start Capturing All Streams");
             List<Task> streamsStartedTasks = new List<Task>();
-
-            foreach (var stream in _streams.Values)
+            try
             {
-                Logger.LogInformation("Start Capturing: {streamId}", stream.Info.Id);
-                var captureStartedTask = stream.StartCapturing(cancellationToken);
-                Logger.LogInformation("Capturing Started: {streamId}", stream.Info.Id);
-                streamsStartedTasks.Add(captureStartedTask);
-            }
+                Logger.LogInformation("Start Capturing All Streams");
 
-            await Task.WhenAll(streamsStartedTasks).ConfigureAwait(false);
-            streamsStartedTasks.Clear();
+                foreach (var stream in _streams.Values)
+                {
+                    Logger.LogInformation("Start Capturing: {streamId}", stream.Info.Id);
+                    var captureStartedTask = stream.StartCapturing(cancellationToken);
+                    Logger.LogInformation("Capturing Started: {streamId}", stream.Info.Id);
+                    streamsStartedTasks.Add(captureStartedTask);
+                }
+
+                //await all start tasks, so that we are sure all streams are running
+                await Task.WhenAll(streamsStartedTasks).ConfigureAwait(false);
+            }
+            finally
+            {
+                streamsStartedTasks.Clear();
+            }
         }
 
         private void CreateCapturingChannel(VideoStreamInfo streamInfo)

--- a/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
+++ b/DetectiCam.Core/VideoCapturing/VideoStreamGrabber.cs
@@ -125,6 +125,7 @@ namespace DetectiCam.Core.VideoCapturing
         public Task StartCapturing(CancellationToken cancellationToken)
         {
             //Create a completion source to signal the moment that the capturing has been started (or has failed).
+            //It is only signalled after the first capture, after that the task worker keeps running
             var capstureStartedTcs = new TaskCompletionSource<Object>();
 
             _executionTask = Task.Run(() =>

--- a/DetectiCam/DetectiCam.csproj
+++ b/DetectiCam/DetectiCam.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.0" />

--- a/DetectiCam/Dockerfile
+++ b/DetectiCam/Dockerfile
@@ -1,4 +1,13 @@
 FROM raimondb/opencv-dotnet-runtime-deps:0.24.0 AS base
+
+# Ubuntu 18
+# RUN apt-get update && apt-get install -y \
+#     libgtk2.0-0 \
+# 	libtesseract4 \
+# 	libdc1394-22 \
+# 	libavformat57 \
+# 	libswscale4 \
+# 	libopenexr22
 COPY --from=raimondb/yolov3-data ["yolov3.weights", "yolov3.cfg", "coco.names", "/yolo-data/"]
 # RUN apt-get update && apt-get install -y \
 #     curl \
@@ -11,7 +20,7 @@ COPY ["DetectiCam.Core/DetectiCam.Core.csproj", "DetectiCam.Core/"]
 RUN dotnet restore "DetectiCam/DetectiCam.csproj" --runtime ubuntu.20.04-x64
 COPY . .
 WORKDIR "/src/DetectiCam"
-RUN dotnet build "DetectiCam.csproj" -c Release --runtime ubuntu.20.04-x64 -o /app/build
+RUN dotnet build "DetectiCam.csproj" -c Release --runtime ubuntu.20.04-x64 --self-contained true -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "DetectiCam.csproj" -c Release --runtime ubuntu.20.04-x64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=false -o /app/publish


### PR DESCRIPTION
THere is an issue in the 4.7+ versions of OpenCVSharp where memory usage doubles.
Therefore downgrade to the 4.6 version, but keep 4.7 of the ubuntu native bindings library so we can continue to use ubuntu 20 and .NET 6.